### PR TITLE
Fix Stateless Component rendering bug

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -41,7 +41,9 @@ function connect (arg1: string | any, arg2 = null): any {
 			propTypes: componentClass.propTypes,
 			contextTypes: componentClass.contextTypes,
 			getDefaultProps: () => componentClass.defaultProps,
-			render: () => componentClass.call(this, this.props, this.context)
+			render() {
+				return componentClass.call(this, this.props, this.context)
+			}
 		});
 
 		return connect(newClass);


### PR DESCRIPTION
The `render` method of stateless component mistakenly binds to the `this` context of the `connect` function.

Should not use the arrow function.